### PR TITLE
Create releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,12 +63,13 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v1
 
-      - name: Build rtype binaries on Ubuntu (desktop)
+      - name: Build rtype binaries on Windows (desktop)
         run: |
           mkdir -p build
           cd build/
           conan install .. --build=missing -c tools.system.package_manager:mode=install -c tools.system.package_manager:sudo=True
           cmake -DCMAKE_BUILD_TYPE=Release -D_WIN32_WINNT=0x0601 ..
+          cd ..
           cmake --build build/
 
       - name: Package

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -81,24 +81,22 @@ jobs:
           name: Windows
           path: |
             ${{ github.workspace }}/build/R-Type-*-win64.msi
-  publish:
-    runs-on: ubuntu-latest
-    needs: [build-on-windows, build-on-ubuntu]
-    permissions:
-      contents: write
-    environment:
-      name: production
-    steps:
-      - uses: actions/checkout@v3
-      - uses: actions/download-artifact@v3
 
-      - name: Debug list directory
-        shell: bash
-        run: |
-          ls -lRa
-      # - name: Upload release binaries
-      #   id: upload_release_asset
-      #   env:
-      #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      #   run: |
-      #     gh release create "${{ github.event.inputs.version }}" -t "${{ github.event.inputs.version }}"  -n "${{ github.event.inputs.body }}" ${{ github.workspace }}/ubuntu-latest/* ${{ github.workspace }}/windows-latest/*
+  create-release:
+    needs: [build-on-ubuntu, build-on-windows]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Debug directory
+        run: ls -lRa
+
+      # - name: Release
+      #   uses: softprops/action-gh-release@v1
+      #   with:
+      #     tag_name: ${{ github.event.inputs.version }}
+      #     body_path: ${{ github.event.inputs.body }}
+      #     token: ${{ secrets.GITHUB_TOKEN }}
+      #     files: |
+      #       ${{ github.workspace }}/build/R-Type-*-win64.msi
+      #       ${{ github.workspace }}/build/R-Type-*-Linux.tar.gz

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,6 +48,15 @@ jobs:
   build-on-windows:
     runs-on: windows-latest
     steps:
+      - name: Cache Conan packages
+        id: cache_windows
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.conan
+            C:\.conan
+          key: ${{ runner.os }}-CreateRelease-${{ hashfiles('**/conanfile.txt') }}
+
       - name: Install conan
         uses: turtlebrowser/get-conan@main
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -70,7 +70,6 @@ jobs:
           conan install .. --build=missing -c tools.system.package_manager:mode=install -c tools.system.package_manager:sudo=True
           cmake -DCMAKE_BUILD_TYPE=Release -D_WIN32_WINNT=0x0601 ..
           cd ..
-          cmake --build build/
 
       - name: Package
         run: |
@@ -93,12 +92,12 @@ jobs:
       - name: Debug directory
         run: ls -lRa
 
-      # - name: Release
-      #   uses: softprops/action-gh-release@v1
-      #   with:
-      #     tag_name: ${{ github.event.inputs.version }}
-      #     body_path: ${{ github.event.inputs.body }}
-      #     token: ${{ secrets.GITHUB_TOKEN }}
-      #     files: |
-      #       ${{ github.workspace }}/build/R-Type-*-win64.msi
-      #       ${{ github.workspace }}/build/R-Type-*-Linux.tar.gz
+      - name: Release
+        uses: softprops/action-gh-release@v1
+        with:
+          tag_name: ${{ github.event.inputs.version }}
+          body_path: ${{ github.event.inputs.body }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+          files: |
+            ${{ github.workspace }}/ubuntu-latest/*
+            ${{ github.workspace }}/windows-latest/*

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -105,5 +105,5 @@ jobs:
           body_path: ${{ github.event.inputs.body }}
           token: ${{ secrets.GITHUB_TOKEN }}
           files: |
-            ${{ github.workspace }}/Linux/*
-            ${{ github.workspace }}/Windows/*
+            ${{ github.workspace }}/Linux/R-Type-0.1.1-Linux.tar.gz
+            ${{ github.workspace }}/Windows/R-Type-0.1.1-win64.msi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,6 +69,7 @@ jobs:
           cd build/
           conan install .. --build=missing -c tools.system.package_manager:mode=install -c tools.system.package_manager:sudo=True
           cmake -DCMAKE_BUILD_TYPE=Release -D_WIN32_WINNT=0x0601 ..
+          cmake --build build/
 
       - name: Package
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -105,5 +105,5 @@ jobs:
           body_path: ${{ github.event.inputs.body }}
           token: ${{ secrets.GITHUB_TOKEN }}
           files: |
-            ${{ github.workspace }}/ubuntu-latest/*
-            ${{ github.workspace }}/windows-latest/*
+            ${{ github.workspace }}/Linux/*
+            ${{ github.workspace }}/Windows/*

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,14 +48,14 @@ jobs:
   build-on-windows:
     runs-on: windows-latest
     steps:
-      - name: Cache Conan packages
-        id: cache_windows
-        uses: actions/cache@v3
-        with:
-          path: |
-            ~/.conan
-            C:\.conan
-          key: ${{ runner.os }}-${{ hashfiles('**/conanfile.txt') }}
+      # - name: Cache Conan packages
+      #   id: cache_windows
+      #   uses: actions/cache@v3
+      #   with:
+      #     path: |
+      #       ~/.conan
+      #       C:\.conan
+      #     key: ${{ runner.os }}-${{ hashfiles('**/conanfile.txt') }}
 
       - name: Install conan
         uses: turtlebrowser/get-conan@main
@@ -86,6 +86,10 @@ jobs:
 
   create-release:
     needs: [build-on-ubuntu, build-on-windows]
+    permissions:
+      contents: write
+    environment:
+      name: production
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -102,8 +102,8 @@ jobs:
         uses: softprops/action-gh-release@v1
         with:
           tag_name: ${{ github.event.inputs.version }}
-          body_path: ${{ github.event.inputs.body }}
+          body: ${{ github.event.inputs.body }}
           token: ${{ secrets.GITHUB_TOKEN }}
           files: |
-            ${{ github.workspace }}/Linux/R-Type-0.1.1-Linux.tar.gz
-            ${{ github.workspace }}/Windows/R-Type-0.1.1-win64.msi
+            ${{ github.workspace }}/Linux/*.tar.gz
+            ${{ github.workspace }}/Windows/*.msi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,14 +48,14 @@ jobs:
   build-on-windows:
     runs-on: windows-latest
     steps:
-      # - name: Cache Conan packages
-      #   id: cache_windows
-      #   uses: actions/cache@v3
-      #   with:
-      #     path: |
-      #       ~/.conan
-      #       C:\.conan
-      #     key: ${{ runner.os }}-${{ hashfiles('**/conanfile.txt') }}
+      - name: Cache Conan packages
+        id: cache_windows
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.conan
+            C:\.conan
+          key: ${{ runner.os }}-${{ hashfiles('**/conanfile.txt') }}
 
       - name: Install conan
         uses: turtlebrowser/get-conan@main
@@ -93,6 +93,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+      - uses: actions/download-artifact@v3
 
       - name: Debug directory
         run: ls -lRa

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,7 +55,7 @@ jobs:
           path: |
             ~/.conan
             C:\.conan
-          key: ${{ runner.os }}-CreateRelease-${{ hashfiles('**/conanfile.txt') }}
+          key: ${{ runner.os }}-${{ hashfiles('**/conanfile.txt') }}
 
       - name: Install conan
         uses: turtlebrowser/get-conan@main

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -72,3 +72,24 @@ jobs:
           name: Windows
           path: |
             ${{ github.workspace }}/build/R-Type-*-win64.msi
+  publish:
+    runs-on: ubuntu-latest
+    needs: [build-on-windows, build-on-ubuntu]
+    permissions:
+      contents: write
+    environment:
+      name: production
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/download-artifact@v3
+
+      - name: Debug list directory
+        shell: bash
+        run: |
+          ls -lRa
+      # - name: Upload release binaries
+      #   id: upload_release_asset
+      #   env:
+      #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      #   run: |
+      #     gh release create "${{ github.event.inputs.version }}" -t "${{ github.event.inputs.version }}"  -n "${{ github.event.inputs.body }}" ${{ github.workspace }}/ubuntu-latest/* ${{ github.workspace }}/windows-latest/*

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -70,6 +70,7 @@ jobs:
           conan install .. --build=missing -c tools.system.package_manager:mode=install -c tools.system.package_manager:sudo=True
           cmake -DCMAKE_BUILD_TYPE=Release -D_WIN32_WINNT=0x0601 ..
           cd ..
+          cmake --build build/
 
       - name: Package
         run: |


### PR DESCRIPTION
This PR aims to:

- Use caches on Windows releases to decrease compilation time

- Create releases with an action that will generate .msi for windows and .tar.gz for UNIX. The files will be available in the [GitHub releases page](https://github.com/JohanCDev/R-Type/releases) of the project. 

To generate a release, run the [action](https://github.com/JohanCDev/R-Type/actions/workflows/release.yml) and write the minor version (o.o.X) X being the version. You also have to add a body, indicating the updates of the release.

Closes #86 